### PR TITLE
Mark the dapr-dashboard chart as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,3 +5,5 @@ You can find all the charts on GitHub [dapr/helm-charts](https://github.com/dapr
 If you have questions you can visit the [Dapr Documentation](https://docs.dapr.io/) or our [Discord Channel](https://discord.com/invite/ptHhX6jc34). 
 
 [Chart documentation over Dapr's GitHub repo](https://github.com/dapr/dapr/blob/master/charts/dapr/README.md)
+
+> **Note:** The `dapr-dashboard` chart is deprecated. The upstream [dapr/dashboard](https://github.com/dapr/dashboard) repository has been archived and the chart will no longer receive updates.

--- a/index.yaml
+++ b/index.yaml
@@ -4941,6 +4941,7 @@ entries:
     urls:
     - https://dapr.github.io/helm-charts/dapr-dashboard-0.15.0.tgz
     version: 0.15.0
+    deprecated: true
   - apiVersion: v2
     appVersion: 0.15.0-rc.2
     created: "2026-06-01T19:44:27.056405308Z"
@@ -4951,6 +4952,7 @@ entries:
     urls:
     - https://dapr.github.io/helm-charts/dapr-dashboard-0.15.0-rc.2.tgz
     version: 0.15.0-rc.2
+    deprecated: true
   - apiVersion: v2
     appVersion: 0.15.0-rc.1
     created: "2026-06-01T19:44:27.056116237Z"
@@ -4961,6 +4963,7 @@ entries:
     urls:
     - https://dapr.github.io/helm-charts/dapr-dashboard-0.15.0-rc.1.tgz
     version: 0.15.0-rc.1
+    deprecated: true
   - apiVersion: v2
     appVersion: 0.14.0
     created: "2026-06-01T19:44:27.055825143Z"
@@ -4971,6 +4974,7 @@ entries:
     urls:
     - https://dapr.github.io/helm-charts/dapr-dashboard-0.14.0.tgz
     version: 0.14.0
+    deprecated: true
   - apiVersion: v2
     appVersion: 0.14.0-rc.1
     created: "2026-06-01T19:44:27.055538115Z"
@@ -4981,6 +4985,7 @@ entries:
     urls:
     - https://dapr.github.io/helm-charts/dapr-dashboard-0.14.0-rc.1.tgz
     version: 0.14.0-rc.1
+    deprecated: true
   - apiVersion: v2
     appVersion: 0.13.0
     created: "2026-06-01T19:44:27.055267772Z"
@@ -4991,6 +4996,7 @@ entries:
     urls:
     - https://dapr.github.io/helm-charts/dapr-dashboard-0.13.0.tgz
     version: 0.13.0
+    deprecated: true
   - apiVersion: v2
     appVersion: 0.13.0-rc.1
     created: "2026-06-01T19:44:27.054982998Z"
@@ -5001,4 +5007,5 @@ entries:
     urls:
     - https://dapr.github.io/helm-charts/dapr-dashboard-0.13.0-rc.1.tgz
     version: 0.13.0-rc.1
+    deprecated: true
 generated: "2026-06-01T19:44:26.447375509Z"


### PR DESCRIPTION
## Summary

- `dapr/dashboard` has been archived; no further chart releases are expected
- Adds `deprecated: true` to all 7 `dapr-dashboard` version entries in `index.yaml` (Helm's standard deprecation marker per the [Chart repository spec](https://helm.sh/docs/topics/chart_repository/#the-index-file))
- Adds a one-line deprecation note to `README.md`
- The `.tgz` artifacts and index entries are intentionally preserved so existing `dapr init` / `dapr upgrade` calls from older CLI versions continue to resolve the chart without error

## What was changed

| File | Change |
|------|--------|
| `index.yaml` | `deprecated: true` added to each of the 7 `dapr-dashboard` entries (versions 0.13.0-rc.1 through 0.15.0) |
| `README.md` | One-line deprecation note added |

## Open question for maintainers

**Preferred deprecation mechanism?** This PR edits `index.yaml` directly. If the index is regenerated from chart sources (e.g. via `helm repo index` in CI), the `deprecated: true` fields would need to be sourced from the chart's `Chart.yaml` instead — or the generation step would need a post-processing patch. Please confirm whether:
1. Direct edits to `index.yaml` are acceptable and stable (no regeneration step that would overwrite them), or
2. The preferred path is to update `Chart.yaml` inside the packaged `.tgz` artifacts (and/or remove the chart sources entirely) and re-run the index generation workflow.

Maintainers may also prefer to fully remove the chart — this PR takes the conservative approach of deprecating-in-place to avoid breaking older CLI versions.

## Test plan
- [ ] `helm repo update && helm search repo dapr/dapr-dashboard --devel` should show the chart as deprecated
- [ ] Existing installs using the chart URL directly should continue to resolve (`.tgz` files untouched)
- [ ] `dapr` chart entries remain unaffected (verified: 353 entries, none marked deprecated)